### PR TITLE
Fix issue with latest gyp that causes copy command to be escaped and fail

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -1,15 +1,4 @@
 {
-  'conditions': [
-      ['OS=="win"', {
-        'variables': {
-          'copy_command%': 'copy',
-        },
-      },{
-        'variables': {
-          'copy_command%': 'cp',
-        },
-      }]
-  ],
   'targets': [
     {
       'target_name': 'node_unqlite',
@@ -33,16 +22,12 @@
       'target_name': 'action_after_build',
       'type': 'none',
       'dependencies': [ 'node_unqlite' ],
-      'actions': [
+      'copies': [
         {
-          'action_name': 'move_node_module',
-          'inputs': [
+          'destination': 'lib',
+          'files': [
             '<@(PRODUCT_DIR)/node_unqlite.node'
-          ],
-          'outputs': [
-            'lib/node_unqlite.node'
-          ],
-          'action': ['<@(copy_command)', '<@(PRODUCT_DIR)/node_unqlite.node', 'lib/node_unqlite.node']
+          ]
         }
       ]
     }

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.3.4",
   "description": "Node.js binding of UnQLite",
   "main": "lib/unqlite.js",
+  "types": "typings/index.d.ts",
   "scripts": {
     "test": "mocha -R spec test/test.js"
   },

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,0 +1,25 @@
+declare module 'unqlite' {
+
+  export const enum OpenMode {
+    OPEN_READONLY = 0x00000001,
+    OPEN_READWRITE = 0x00000002,
+    OPEN_CREATE = 0x00000004,
+    OPEN_EXCLUSIVE = 0x00000008,
+    OPEN_TEMP_DB = 0x00000010,
+    OPEN_NOMUTEX = 0x00000020,
+    OPEN_OMIT_JOURNALING = 0x00000040,
+    OPEN_IN_MEMORY = 0x00000080,
+    OPEN_MMAP = 0x00000100
+  }
+
+  export class Database {
+    constructor(filename: string);
+    open(openMode: OpenMode, callback: (err: any) => void);
+    close(callback: (err: any) => void);
+    store(key: string, value: string, callback: (err: any, key: string, value: string) => void);
+    append(key: string, value: string, callback: (err: any, key: string, value: string) => void);
+    fetch(key: string, callback: (err: any, key: string, value: string) => void);
+    delete(key: string, callback: (err: any, key: string) => void);
+  }
+
+}


### PR DESCRIPTION
Workaround/fix for gyp issue: https://github.com/nodejs/node-gyp/issues/1151

Likely more appropriate to use gyp copies anyway.